### PR TITLE
A11y tweaks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -129,7 +129,7 @@ Good luck, be brave, take small deliberate steps, one at a time.
 === Is there a complete solution somewhere?
 
 If you want a complete solution to study, you can find one
-https://github.com/juxt/spin/blob/master/examples/demo/src/demo.clj[here].
+https://github.com/juxt/spin/blob/master/examples/demo/src/demo.clj[in the Spin example code].
 
 === How to get involved?
 

--- a/README.adoc
+++ b/README.adoc
@@ -71,7 +71,7 @@ The way we will achieve such code _economy_ is by using a declarative
 approach. Where possible, your code should behave according to the details of
 individual resources provided as input argument.
 
-In our view, all code should either be implementing a compiler or an interpretter.
+In our view, all code should either be implementing a compiler or an interpreter.
 
 TIP: Another benefit of this approach is that having separated the code from the
 data declarations that drive it, you can store that data inside a
@@ -181,7 +181,7 @@ step>>.
 
 NOTE: How you can tell this is beyond the scope of this guide. It might be a feature
 of the web listener you are working with. Or you might want to build something
-that signals that new web requests should temporarily suspended. If you don't
+that signals that new web requests should be temporarily suspended. If you don't
 know, just skip this section, it's optional.
 
 ====
@@ -203,7 +203,7 @@ Your whole handler should be wrapped in a
 https://clojuredocs.org/clojure.core/try[try/catch] block.
 
 The catch block should catch the exception, extract the Ring response, and
-return it to the Ring adapter of th web server you are running.
+return it to the Ring adapter of the web server you are running.
 ====
 
 ==== References
@@ -447,7 +447,7 @@ Representation metadata may include the following:
 |===
 |Key|Description|Example
 
-|"content-type"|The representation's media type. If a `text` type, also inclues the charset|text/html;charset=utf-8
+|"content-type"|The representation's media type. If a `text` type, also includes the charset|text/html;charset=utf-8
 |"content-encoding"|How the representation's data is encoded|gzip
 |"content-language"|The human language used|en-US
 |"content-location"|The URL of the representation, if different from the request URL|
@@ -569,7 +569,7 @@ resource, parse its value.
 
 . Add the `Date` header, using the message origination date stored in <<record-the-date>>.
 
-. If supported, add an `Accept Ranges` header.
+. If supported, add an `Accept-Ranges` header.
 
 . Add the representation metadata to the response headers.
 
@@ -613,7 +613,7 @@ the resource needs to change, and that might involve changing all its current
 representations together. Ideally, this should happen atomically (all changes
 should succeed together, or fail together).
 
-We must also evaluate any preconditions just before perform the required
+We must also evaluate any preconditions just before performing the required
 updates. To guarentee that we will avoid losing updates, we should run the
 preconditions at the beginning of the same transaction. That way, race
 conditions will be avoided.

--- a/css/juxt.css
+++ b/css/juxt.css
@@ -179,8 +179,8 @@ p.lead, .paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type
 div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; direction: ltr; }
 
 /* Default Link Styles */
-a { color: #2ba6cb; text-decoration: none; line-height: inherit; }
-a:hover, a:focus { color: #2795b6; }
+a { color: #3c3c43; text-decoration: none; line-height: inherit; }
+a:hover, a:focus { color: #f4901d; }
 a img { border: none; }
 
 /* Default paragraph styles */
@@ -328,9 +328,10 @@ b.button:after { content: "]"; padding: 0 2px 0 3px; }
 #toc a { text-decoration: none; }
 #toc a:active { text-decoration: underline; }
 
-#toctitle { color: #ddd; font-size: 1.2em; }
+#toctitle { color: #d67214; font-size: 1.2em; }
 
 @media only screen and (min-width: 768px) { #toctitle { font-size: 1.375em; }
+  #toc.toc2 a { color: #d67214; }
   body.toc2 { padding-left: 15em; padding-right: 0; }
   #toc.toc2 { margin-top: 0 !important; background-color: #000; position: fixed; width: 15em; left: 0; top: 0; border-right: 1px solid #dddddd; border-top-width: 0 !important; border-bottom-width: 0 !important; z-index: 1000; padding: 1.25em 1em; height: 100%; overflow: auto; }
   #toc.toc2 #toctitle { margin-top: 0; margin-bottom: 0.8rem; font-size: 1.2em; }
@@ -678,7 +679,7 @@ b.conum * { color: inherit !important; }
 
 *, *:after, *:before { box-sizing: border-box; }
 
-a { color: #d67214; text-decoration: underline; }
+#content a { text-decoration: underline; }
 a.fa { text-decoration: none; }
 
 h1 { font-size: 2em; }

--- a/docinfo-footer.html
+++ b/docinfo-footer.html
@@ -1,6 +1,6 @@
 <div id="footer">
   <a href="https://juxt.pro">
-    <img style="width: 80px; margin-bottom: 20px" src="https://www.juxt.land/logo.svg">
+    <img style="width: 80px; margin-bottom: 20px" src="https://www.juxt.land/logo.svg" alt="JUXT homepage">
   </a>
   <div id="footer-text"><p>Copyright © 2020-2021, JUXT LTD.</p></div>
 


### PR DESCRIPTION
This addresses a couple of accessibility concerns, namely a couple of links that could be more descriptive, and low colour contrast on the orange text of links in body text. I also spotted a couple of typos, which are fixed.

There's one quote (in the "routing" box) which is still failing standards on contrast, but only by 0.1 so I didn't bother fixing it.

There's a dead link `<<error-response>>` at `README.adoc:535`, but I wasn't sure what that was actually meant to link to?